### PR TITLE
support macOS big sur which changed userAgent to 11_0_0

### DIFF
--- a/deviceTemplate.js
+++ b/deviceTemplate.js
@@ -66,7 +66,7 @@ var os = (function() {
 
   switch (os) {
     case "Mac OS X":
-      osVersion = /Mac OS X (10[\.\_\d]+)/.exec(nAgt)[1];
+      osVersion = /Mac OS X ([\.\_\d]+)/.exec(nAgt)[1]
       break;
 
     case "Android":


### PR DESCRIPTION
macOS Big Sur has changed the useAngent to "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36", fixed the origin regexp to get OS version.